### PR TITLE
Add `erg.restartLanguageServer` command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: local
+    hooks:
+      - id: npx-lint
+        name: npx-lint
+        entry: npx lint-staged
+        language: system
+        pass_filenames: false
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -13,6 +13,7 @@
         { "open": "{", "close": "}" },
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "#[", "close": "]#", "notIn": ["string"] }
     ],
@@ -20,7 +21,9 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["\"", "\""]
+        ["'", "'"],
+        ["\"", "\""],
+        ["|", "|"]
     ],
     "onEnterRules": [
         {
@@ -29,7 +32,7 @@
             "action": { "indent": "indent" }
         },
         {
-            // e.g. `#[|]#`
+            // e.g. `#[|]#`, `#[|` (`|` is the cursor)
             "beforeText": {
                 "pattern": "^\\s*.*#\\[.*$"
             },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
 		"onLanguage:erg"
 	],
 	"contributes": {
+		"commands": [
+			{
+				"title": "Restart Language Server",
+				"category": "Erg",
+				"command": "erg.restartLanguageServer"
+			}
+		],
 		"languages": [
 			{
 				"id": "erg",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "npm run compile-tests && npm run compile && npm run lint",
 		"test": "node ./out/test/runTest.js",
+		"type-check": "tsc --noEmit",
 		"lint": "rome check .",
 		"format": "rome format .",
 		"lint:fix": "rome check --apply .",
@@ -79,5 +80,8 @@
 		"typescript": "^4.9.4",
 		"webpack": "^5.75.0",
 		"webpack-cli": "^5.0.1"
+	},
+	"lint-staged": {
+		"*": "rome format --write"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,42 +1,67 @@
-// import { LanguageClientOptions } from "vscode-languageclient";
-import { ExtensionContext, window } from "vscode";
-import { LanguageClient, ServerOptions } from "vscode-languageclient/node";
-import { spawnSync } from "child_process";
+import { ExtensionContext, commands, window } from "vscode";
+import {
+	LanguageClient,
+	LanguageClientOptions,
+	ServerOptions,
+} from "vscode-languageclient/node";
+import { spawn } from "child_process";
 
 let client: LanguageClient | undefined;
 
-export async function activate_els(context: ExtensionContext) {
-    let serverOptions;
-    let result = spawnSync("erg", ["--build-features"]);
-    if (result.stdout.toString().includes("els")) {
-        serverOptions = {
-            command: "erg",
-            args: ["--language-server"]
-        };
-    } else {
-        serverOptions = {
-            command: "els",
-            args: []
-        };
-    }
-    const clientOptions = {
-        documentSelector: [
-            {
-                scheme: "file",
-                language: "erg",
-            }
-        ],
-    };
-    client = new LanguageClient("els", serverOptions, clientOptions);
-    context.subscriptions.push(client.start());
+async function startLanguageClient(context: ExtensionContext) {
+	try {
+		const buildFeatures = spawn("erg", ["--build-features"]);
+		let result = "";
+		for await (const chunk of buildFeatures.stdout) {
+			console.log(chunk);
+			result += chunk;
+		}
+		let serverOptions: ServerOptions;
+		if (result.includes("els")) {
+			serverOptions = {
+				command: "erg",
+				args: ["--language-server"],
+			};
+		} else {
+			serverOptions = {
+				command: "els",
+				args: [],
+			};
+		}
+		const clientOptions: LanguageClientOptions = {
+			documentSelector: [
+				{
+					scheme: "file",
+					language: "erg",
+				},
+			],
+		};
+		client = new LanguageClient("els", serverOptions, clientOptions);
+		context.subscriptions.push(client.start());
+	} catch (e) {
+		window.showErrorMessage(
+			"Failed to start ELS (Erg Language Server). Please make sure you have erg (built with `els` feature) or els installed.",
+		);
+	}
+}
+
+async function restartLanguageClient(context: ExtensionContext) {
+	if (client === undefined) {
+		window.showErrorMessage("Failed to restart ELS (Erg Language Server).");
+		return;
+	}
+	await client.stop();
+	client.outputChannel.dispose();
+	await startLanguageClient(context);
 }
 
 export async function activate(context: ExtensionContext) {
-    try {
-        activate_els(context);
-    } catch (e) {
-        window.showErrorMessage("Failed to start ELS (Erg Language Server). Please make sure you have erg (built with `els` feature) or els installed.");
-    }
+	context.subscriptions.push(
+		commands.registerCommand("erg.restartLanguageServer", () =>
+			restartLanguageClient(context),
+		),
+	);
+	await startLanguageClient(context);
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,6 @@ async function startLanguageClient(context: ExtensionContext) {
 		const buildFeatures = spawn("erg", ["--build-features"]);
 		let result = "";
 		for await (const chunk of buildFeatures.stdout) {
-			console.log(chunk);
 			result += chunk;
 		}
 		let serverOptions: ServerOptions;


### PR DESCRIPTION
The command to restart language server is useful when language server is not doing well, and seems to be well implemented in other extensions
I made a few other improvements to `language-configuration.json` and added pre-commit