### PR TITLE
Support `vscode-erg.executablePath`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
 			"title": "vscode-erg",
 			"properties": {
 				"vscode-erg.ergpath.path": {
-					"type": ["string" , "null"],
-					"default": null,
+					"type": "string",
+					"default": "",
 					"description": "Path to `.erg` directory"
 				},
-				"vscode-erg.executable.path": {
-					"type": ["string" , "null"],
-					"default": null,
+				"vscode-erg.executablePath": {
+					"type": "string",
+					"default": "",
 					"description": "Path to `erg` executable"
 				},
 				"vscode-erg.lsp.inlayhints": {
@@ -70,7 +70,9 @@
 		}
 	},
 	"scripts": {
+		"vscode:publish": "vsce publish",
 		"vscode:prepublish": "npm run package",
+		"vscode:package": "vsce package",
 		"compile": "webpack",
 		"watch": "webpack --watch",
 		"package": "webpack --mode production --devtool hidden-source-map",


### PR DESCRIPTION
- Supported `vscode-erg.executablePath`
- Replaced languageclinet restart with one provided by API